### PR TITLE
feat: add light mode styles

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -73,8 +73,8 @@ export default async function DividerDocs({
 
             return (
               <TabsContent key={tab} value={tab} className='mb-8'>
-                <div className='rounded-lg border border-zinc-800 bg-zinc-900'>
-                  <div className='flex items-center justify-between px-4 py-2 border-b border-zinc-800'>
+                <div className='rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900'>
+                  <div className='flex items-center justify-between px-4 py-2 border-b border-zinc-200 dark:border-zinc-800'>
                     <h3>{tab}</h3>
                     <CopyButton
                       text={installCommand}
@@ -110,8 +110,8 @@ export default async function DividerDocs({
 
             return (
               <TabsContent key={tab} value={tab} className='mb-8'>
-                <div className='rounded-lg border border-zinc-800 bg-zinc-900'>
-                  <div className='flex items-center justify-between px-4 py-2 border-b border-zinc-800'>
+                <div className='rounded-lg border border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900'>
+                  <div className='flex items-center justify-between px-4 py-2 border-b border-zinc-200 dark:border-zinc-800'>
                     <h3>{tab}</h3>
                     <CopyButton text={usageCommand} aria-label='Copy command' />
                   </div>

--- a/app/[lang]/playground/Playground.tsx
+++ b/app/[lang]/playground/Playground.tsx
@@ -194,7 +194,7 @@ export default function PlaygroundPage({ dict }: PlaygroundPageProps) {
             <input
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              className='w-full h-8 p-2 rounded border bg-zinc-900 text-white'
+              className='w-full h-8 p-2 rounded border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-white'
               placeholder={dict.playground.string.placeholder}
             />
           </TabsContent>
@@ -203,7 +203,7 @@ export default function PlaygroundPage({ dict }: PlaygroundPageProps) {
             <textarea
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              className='w-full h-24 p-2 rounded border bg-zinc-900 text-white'
+              className='w-full h-24 p-2 rounded border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-white'
               placeholder={dict.playground.array.placeholder}
             />
           </TabsContent>
@@ -214,7 +214,7 @@ export default function PlaygroundPage({ dict }: PlaygroundPageProps) {
           <input
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            className='w-full h-8 p-2 rounded border bg-zinc-900 text-white'
+            className='w-full h-8 p-2 rounded border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-white'
             placeholder={
               functionType === DIVIDER.CSV_DIVIDER
                 ? '"a, ""quoted""",b'
@@ -237,7 +237,7 @@ export default function PlaygroundPage({ dict }: PlaygroundPageProps) {
           <textarea
             value={separators}
             onChange={(e) => setSeparators(e.target.value)}
-            className='w-full h-16 p-2 rounded border bg-zinc-900 text-white'
+            className='w-full h-16 p-2 rounded border border-zinc-200 bg-white text-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-white'
           />
         </div>
       ) : null}
@@ -338,7 +338,7 @@ export default function PlaygroundPage({ dict }: PlaygroundPageProps) {
       </section>
 
       {output !== null && (
-        <div className='p-4 border rounded bg-zinc-800 text-white whitespace-pre-wrap break-words mb-6'>
+        <div className='p-4 border rounded bg-zinc-100 text-zinc-900 whitespace-pre-wrap break-words mb-6 dark:bg-zinc-800 dark:text-white border-zinc-200 dark:border-zinc-800'>
           <strong> {dict.playground.output.title}:</strong>
           <pre className='mt-2'>{JSON.stringify(output, null, 2)}</pre>
         </div>

--- a/app/ui/components/breadcrumbs.tsx
+++ b/app/ui/components/breadcrumbs.tsx
@@ -18,7 +18,10 @@ export function Breadcrumbs({ paths }: BreadcrumbsProps) {
         >
           {!isFirstPath(index) && <ChevronRight className='w-4 h-4' />}
           {isNavigable(path) ? (
-            <Link href={path.href} className='text-white hover:underline'>
+            <Link
+              href={path.href}
+              className='text-zinc-900 hover:underline dark:text-white'
+            >
               {path.label}
             </Link>
           ) : (

--- a/app/ui/components/card.tsx
+++ b/app/ui/components/card.tsx
@@ -4,7 +4,7 @@ export function Card({ id, children }: CardProps) {
   return (
     <div
       id={id}
-      className='block max-w-sm p-6 border rounded-lg shadow-sm bg-zinc-900 border-zinc-800'
+      className='block max-w-sm p-6 border rounded-lg shadow-sm bg-white border-zinc-200 dark:bg-zinc-900 dark:border-zinc-800'
     >
       {children}
     </div>

--- a/app/ui/components/footer.tsx
+++ b/app/ui/components/footer.tsx
@@ -2,7 +2,7 @@ import { LogoLink } from '@/ui/components/logo-link';
 
 export function Footer() {
   return (
-    <footer className='border-t border-zinc-800 py-8'>
+    <footer className='border-t border-zinc-200 py-8 dark:border-zinc-800'>
       <div className='container mx-auto flex flex-col md:flex-row justify-between items-center'>
         <div className='flex items-center gap-2 mb-4 md:mb-0'>
           <LogoLink />
@@ -14,7 +14,7 @@ export function Footer() {
           Made with 💚 by{' '}
           <a
             href='https://github.com/nyaomaru'
-            className='underline hover:text-white'
+            className='underline hover:text-zinc-900 dark:hover:text-white'
           >
             nyaomaru
           </a>

--- a/app/ui/components/header.tsx
+++ b/app/ui/components/header.tsx
@@ -13,7 +13,7 @@ export function Header() {
   const currentLang = pathname?.split('/')[1] || 'en';
 
   return (
-    <header className='sticky top-0 z-10 border-b border-zinc-800 bg-zinc-950/80 backdrop-blur-sm'>
+    <header className='sticky top-0 z-10 border-b border-zinc-200 bg-white/80 dark:border-zinc-800 dark:bg-zinc-950/80 backdrop-blur-sm'>
       <div className='container mx-auto flex h-16 items-center justify-between'>
         <div className='flex items-center gap-2'>
           <LogoLink />

--- a/app/ui/components/labeled-input.tsx
+++ b/app/ui/components/labeled-input.tsx
@@ -15,7 +15,7 @@ export function LabeledInput({
     <label className='flex items-center gap-2'>
       <span className='text-sm'>{label}</span>
       <input
-        className='w-16 rounded border bg-zinc-900 text-white px-2 py-1 font-mono'
+        className='w-16 rounded border border-zinc-200 bg-white text-zinc-900 px-2 py-1 font-mono dark:border-zinc-800 dark:bg-zinc-900 dark:text-white'
         maxLength={maxLength}
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/app/ui/components/labeled-number-input.tsx
+++ b/app/ui/components/labeled-number-input.tsx
@@ -36,7 +36,7 @@ export function LabeledNumberInput({
         placeholder={placeholder}
         className={clsx(
           widthClass,
-          'p-1 rounded border bg-zinc-900 text-white focus:outline-none focus:ring-1 focus:ring-white'
+          'p-1 rounded border border-zinc-200 bg-white text-zinc-900 focus:outline-none focus:ring-1 focus:ring-zinc-900 dark:border-zinc-800 dark:bg-zinc-900 dark:text-white dark:focus:ring-white'
         )}
       />
     </div>

--- a/app/ui/components/language-switcher.tsx
+++ b/app/ui/components/language-switcher.tsx
@@ -43,11 +43,14 @@ export function LanguageSwitcher() {
           <Globe className='h-4 w-4' />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align='end' className='z-10 bg-black'>
+      <DropdownMenuContent
+        align='end'
+        className='z-10 bg-white text-zinc-900 dark:bg-black dark:text-white'
+      >
         {locales.map(({ code, label, flag }) => (
           <DropdownMenuItem
             className={clsx(
-              'cursor-pointer flex m-2 bg-black',
+              'cursor-pointer flex m-2 bg-white text-zinc-900 dark:bg-black dark:text-white',
               code === currentLocale ? 'text-primary' : ''
             )}
             key={code}

--- a/app/ui/components/scroll-to-top-button.tsx
+++ b/app/ui/components/scroll-to-top-button.tsx
@@ -29,7 +29,7 @@ export function ScrollToTopButton() {
       aria-label='Scroll to top'
       onClick={scrollToTop}
       className={clsx(
-        'fixed bottom-5 right-5 p-3 bg-gray-800 text-white rounded-full shadow-lg transition-opacity cursor-pointer hover:text-primary',
+        'fixed bottom-5 right-5 p-3 bg-zinc-200 text-zinc-900 rounded-full shadow-lg transition-opacity cursor-pointer hover:text-primary dark:bg-gray-800 dark:text-white',
         isVisible ? 'opacity-100' : 'opacity-0 pointer-events-none'
       )}
     >

--- a/app/ui/components/select.tsx
+++ b/app/ui/components/select.tsx
@@ -21,7 +21,7 @@ export function Select<T extends string>({
     <RadixSelect.Root value={value} onValueChange={onValueChange}>
       <RadixSelect.Trigger
         className={clsx(
-          'w-1xl inline-flex items-center justify-between rounded-md border border-white bg-zinc-900 px-3 py-2 text-sm text-white shadow-sm focus:outline-none focus:ring-1 hover:text-primary hover:border-primary cursor-pointer',
+          'w-1xl inline-flex items-center justify-between rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-900 shadow-sm focus:outline-none focus:ring-1 hover:text-primary hover:border-primary cursor-pointer dark:border-white dark:bg-zinc-900 dark:text-white',
           className
         )}
       >
@@ -34,14 +34,14 @@ export function Select<T extends string>({
       <RadixSelect.Portal>
         <RadixSelect.Content
           side='bottom'
-          className='z-50 mt-1 w-full rounded-md bg-zinc-900 text-white shadow-md'
+          className='z-50 mt-1 w-full rounded-md bg-white text-zinc-900 shadow-md dark:bg-zinc-900 dark:text-white'
         >
           <RadixSelect.Viewport className='p-1'>
             {options.map((option) => (
               <RadixSelect.Item
                 key={option}
                 value={option}
-                className='flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-zinc-800 focus:bg-zinc-800'
+                className='flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm text-zinc-900 outline-none hover:bg-zinc-100 focus:bg-zinc-100 dark:text-white dark:hover:bg-zinc-800 dark:focus:bg-zinc-800'
               >
                 <RadixSelect.ItemText>{option}</RadixSelect.ItemText>
                 <RadixSelect.ItemIndicator className='ml-auto'>

--- a/app/ui/components/tabs.tsx
+++ b/app/ui/components/tabs.tsx
@@ -15,8 +15,8 @@ const baseListClass =
 const baseTriggerClass = clsx(
   'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-2 text-sm font-medium',
   'ring-offset-background transition-all focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-  'hover:text-primary hover:border-primary cursor-pointer border border-zinc-950',
-  'data-[state=active]:border-white data-[state=active]:text-white'
+  'hover:text-primary hover:border-primary cursor-pointer border border-zinc-200 dark:border-zinc-950',
+  'data-[state=active]:border-black data-[state=active]:text-black dark:data-[state=active]:border-white dark:data-[state=active]:text-white'
 );
 
 const baseContentClass = 'mt-2 focus:outline-none';

--- a/app/ui/divider-docs/api-reference-card.tsx
+++ b/app/ui/divider-docs/api-reference-card.tsx
@@ -7,7 +7,7 @@ export function APIReferenceCard({
   options,
 }: APIReferenceCardProps) {
   return (
-    <div className='rounded-lg border border-zinc-800 bg-zinc-900 p-6 space-y-6'>
+    <div className='rounded-lg border border-zinc-200 bg-white p-6 space-y-6 dark:border-zinc-800 dark:bg-zinc-900'>
       <div>
         <h3 className='text-xl font-bold mb-2'>{title}</h3>
         {description && <p>{description}</p>}
@@ -18,7 +18,7 @@ export function APIReferenceCard({
         <ul className='list-disc pl-6 space-y-2'>
           {parameters.map((param) => (
             <li key={param.name}>
-              <code className='text-sm bg-zinc-800 px-1 py-0.5 rounded'>
+              <code className='text-sm bg-zinc-100 px-1 py-0.5 rounded dark:bg-zinc-800'>
                 {param.name}
               </code>{' '}
               : {param.description}
@@ -33,7 +33,7 @@ export function APIReferenceCard({
           <ul className='list-disc pl-6 space-y-2'>
             {options.map((option) => (
               <li key={option.name}>
-                <code className='text-sm bg-zinc-800 px-1 py-0.5 rounded'>
+                <code className='text-sm bg-zinc-100 px-1 py-0.5 rounded dark:bg-zinc-800'>
                   {option.name}
                 </code>{' '}
                 : {option.description}

--- a/app/ui/global.css
+++ b/app/ui/global.css
@@ -11,7 +11,7 @@
   }
 
   body {
-    @apply bg-zinc-950 text-white;
+    @apply bg-white text-zinc-900 dark:bg-zinc-950 dark:text-white;
   }
 
   code {


### PR DESCRIPTION
## Summary
- add light theme defaults to global styles
- switch header, language switcher, and other UI to light/dark classes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b43b0cb138832db9326fac60181829