### PR TITLE
Restore server layout with client-side theme handling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next';
 import { Header } from '@/ui/components/header';
 import { Footer } from '@/ui/components/footer';
 import { ScrollToTopButton } from '@/ui/components/scroll-to-top-button';
+import ThemeClient from './theme-client';
 
 export const metadata: Metadata = {
   title: 'Divider',
@@ -38,15 +39,15 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang='en'>
-      <body>
+    <html lang='en' suppressHydrationWarning>
+      <ThemeClient>
         <div className='min-h-screen'>
           <Header />
           {children}
           <ScrollToTopButton />
           <Footer />
         </div>
-      </body>
+      </ThemeClient>
     </html>
   );
 }

--- a/app/lib/use-theme.ts
+++ b/app/lib/use-theme.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('theme') as Theme) || 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const root = document.documentElement.classList;
+
+    if (theme === 'dark') {
+      root.add('dark');
+    } else {
+      root.remove('dark');
+    }
+
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return { theme, toggleTheme } as const;
+}

--- a/app/theme-client.tsx
+++ b/app/theme-client.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useTheme } from '@/lib/use-theme';
+
+export default function ThemeClient({ children }: { children: ReactNode }) {
+  const { theme } = useTheme();
+
+  return (
+    <body className={theme === 'dark' ? 'dark' : undefined}>
+      {children}
+    </body>
+  );
+}
+


### PR DESCRIPTION
## Summary
- restore `app/layout.tsx` as a server component with metadata
- add `ThemeClient` client component to apply dark mode using `useTheme`

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b43b0c4f88832dad3ac5f51482d087