### PR TITLE
fix: return 404 for invalid locale routes

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -5,23 +5,23 @@ import { FeatureCard } from '@/ui/components/feature-card';
 import { CodeBlock } from '@/ui/components/code-block';
 import { APIReferenceCard } from '@/ui/divider-docs/api-reference-card';
 import { installTabs, installCode, usageTabs, usageCode } from '@/lib/docs';
-import { getDictionary, type Locale } from '@/lib/dictionaries';
+import { getDictionary, localeCodes } from '@/lib/dictionaries';
 import { generateApiReferences } from '@/lib/api-references';
 import { generatePresets } from '@/lib/presets';
 import Image from 'next/image';
 import Link from 'next/link';
 
 export async function generateStaticParams() {
-  return [{ lang: 'en' }, { lang: 'ja' }, { lang: 'nl' }];
+  return localeCodes.map((lang) => ({ lang }));
 }
 
 export default async function DividerDocs({
   params,
 }: {
-  params: Promise<{ lang: Locale }>;
+  params: Promise<{ lang: string }>;
 }) {
   const { lang } = await params;
-  const dict = await getDictionary(lang ?? 'en');
+  const dict = await getDictionary(lang);
 
   const apiReferences = generateApiReferences(dict.top);
   const presets = generatePresets(dict.top);

--- a/app/[lang]/playground/page.tsx
+++ b/app/[lang]/playground/page.tsx
@@ -1,13 +1,13 @@
-import { getDictionary, type Locale } from '@/lib/dictionaries';
+import { getDictionary } from '@/lib/dictionaries';
 import Playground from './Playground';
 
 export default async function PlaygroundWrapper({
   params,
 }: {
-  params: Promise<{ lang: Locale }>;
+  params: Promise<{ lang: string }>;
 }) {
   const { lang } = await params;
-  const dict = await getDictionary(lang ?? 'en');
+  const dict = await getDictionary(lang);
 
   return <Playground dict={dict} />;
 }

--- a/app/lib/dictionaries.ts
+++ b/app/lib/dictionaries.ts
@@ -1,6 +1,20 @@
 import 'server-only';
 
-export type Locale = 'en' | 'nl' | 'ja';
+import { notFound } from 'next/navigation';
+import type {
+  PlaygroundDictionary,
+  TopDictionary,
+} from '@/types/dictionaries';
+
+export const localeCodes = ['en', 'nl', 'ja'] as const;
+
+export type Locale = (typeof localeCodes)[number];
+
+type Dictionary = TopDictionary & PlaygroundDictionary;
+
+export function isLocale(value: string): value is Locale {
+  return localeCodes.includes(value as Locale);
+}
 
 const dictionaries = {
   en: () =>
@@ -9,6 +23,12 @@ const dictionaries = {
     import('../../dictionaries/nl.json').then((module) => module.default),
   ja: () =>
     import('../../dictionaries/ja.json').then((module) => module.default),
-};
+} satisfies Record<Locale, () => Promise<Dictionary>>;
 
-export const getDictionary = async (locale: Locale) => dictionaries[locale]();
+export async function getDictionary(locale: string): Promise<Dictionary> {
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  return dictionaries[locale]();
+}

--- a/app/types/dictionaries/top.ts
+++ b/app/types/dictionaries/top.ts
@@ -38,6 +38,7 @@ export type TopDictionary = {
     };
     api: {
       title: string;
+      fullReferenceLinkText: string;
       description: {
         divider: string;
         dividerFirst: string;


### PR DESCRIPTION
## Description

- validate dynamic locale parameters before loading dictionaries
- return `notFound()` for unsupported locales
- share typed locale definitions with static route generation